### PR TITLE
Patch from upstream to fix Data::Dumper bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG DISTRO="alpine"
-ARG DISTRO_VARIANT="3.16"
+ARG DISTRO_VARIANT="3.19"
 
 FROM docker.io/tiredofit/nginx:${DISTRO}-${DISTRO_VARIANT}
 LABEL maintainer="Dave Conroy (github.com/tiredofit)"
@@ -110,6 +110,10 @@ RUN source /assets/functions/00-container && \
     mkdir -p /assets/install && \
     curl -sSL https://github.com/backuppc/backuppc/releases/download/$BACKUPPC_VERSION/BackupPC-$BACKUPPC_VERSION.tar.gz | tar xvfz - --strip 1 -C /assets/install && \
     \
+    && apk add patch \
+    && curl -o /assets/install/patchfile.patch https://github.com/backuppc/backuppc/commit/2c9270b9b849b2c86ae6301dd722c97757bc9256.patch \
+    && cd /assets/install \
+    && patch -p1 < patchfile.patch \
     package remove .backuppc-build-deps && \
     package cleanup && \
     rm -rf /root/.cpanm \


### PR DESCRIPTION
let me try to explain why I want to patch this from upstream (the code is from the main developer but never released)

first with version of smbclient < 4.16 we have an issue that we cannot use the smbclient, see  https://github.com/backuppc/backuppc/issues/404#issuecomment-1890776117

the version of samba 4 in alpine 3.16 breaks the smbclient tar backup, hence I go the idea to upgrade to 3.17/.3.18/3.19/3.20 but I faced a bug that the configuration is badly rewritten, this bug comes from directly from backuppc and it has been fixed by the main developer but never released, we still user 4.4.0 since years now, see upstream https://github.com/backuppc/backuppc/issues/466

redhat itself faced this issue, you can have a bug report https://bugzilla.redhat.com/show_bug.cgi?id=2091514

They fixed it by applying the patch https://github.com/backuppc/backuppc/commit/2c9270b9b849b2c86ae6301dd722c97757bc9256.patch

you can see it in the srpm https://koji.fedoraproject.org/koji/rpminfo?rpmID=31776462


so my idea is to upgrade to a major version of alpine (> 3.16) and to patch the source of BackupPC to avoid the bug of configuration badlu rewritten by Data::Dumper versions >= 2.182

